### PR TITLE
linux(debian)環境で動かなかった部分を修正しました

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,7 @@
 DOCKER_COMPOSE := docker-compose -f ./docker_env/docker-compose.yml
 DOCKER_EXEC := docker exec -it
 CONTAINER_NAME := review
+OPEN_COMMAND := open
 
 ps:
 	$(DOCKER_COMPOSE) ps
@@ -32,7 +33,7 @@ vivliostyle/setup:
 	$(DOCKER_COMPOSE) exec $(CONTAINER_NAME) /bin/bash -ci "./docker_env/review/vivliostyle_setup.sh"
 
 vivliostyle/%:
-	$(DOCKER_COMPOSE) exec $(CONTAINER_NAME) /bin/bash -ci "npm run vivliostyle/$*"
+	$(DOCKER_COMPOSE) exec -T $(CONTAINER_NAME) /bin/bash -ci "npm run vivliostyle/$*"
 
 # ===================================================
 # review
@@ -42,7 +43,7 @@ review/setup:
 	$(DOCKER_COMPOSE) exec $(CONTAINER_NAME) /bin/bash -ci "./setup.sh"
 
 review/%:
-	$(DOCKER_COMPOSE) exec $(CONTAINER_NAME) /bin/bash -ci "npm run review/$*"
+	$(DOCKER_COMPOSE) exec -T $(CONTAINER_NAME) /bin/bash -ci "npm run review/$*"
 
 # ===================================================
 # npm run {command}
@@ -66,11 +67,11 @@ server/kill: review/kill vivliostyle/kill
 build/pdf: npm/run/css
 	$(MAKE) server
 	$(DOCKER_COMPOSE) exec $(CONTAINER_NAME) /bin/bash -ci "node docker_env/scripts/pdf.js $(PDF) $(VIVLIOSTYLE_VIEWER_URL)#x=$(HTML_URL) $(PAGE_FORMAT)"
-	open $(PDF)
+	$(OPEN_COMMAND) $(PDF) &
 
 build/browser: npm/run/css
 	$(MAKE) server
-	open $(VIVLIOSTYLE_VIEWER_URL)#x=$(HTML_URL)
+	$(OPEN_COMMAND) $(VIVLIOSTYLE_VIEWER_URL)#x=$(HTML_URL) &
 
 css/pdf:
 	$(MAKE) -j build/pdf


### PR DESCRIPTION
はじめまして。[ブログの記事](http://at-grandpa.hatenablog.jp/entry/2018/08/20/121043) を読んで使おうとしたのですが、私の環境 (debian sid) で動かなかった部分があったので修正しました。
ちょっと他の環境で試してないので、私の環境が変なだけかもしれませんが...。

### "the input device is not a TTY" がでる

`make css/pdf` および `make css/browser` を実行した時に次のようなエラーが出て止まります。

```
docker-compose -f ./docker_env/docker-compose.yml exec review /bin/bash -c "npm run review/up"
docker-compose -f ./docker_env/docker-compose.yml exec review /bin/bash -c "npm run vivliostyle/up"
the input device is not a TTY
make[2]: *** [Makefile:36: vivliostyle/up] エラー 1
```

これは `docker-compose exec -T` にすることで修正できました。

### open コマンドの決め打ちが微妙に困る

Linux では `open` コマンドがデフォルトでない場合があり、代わりに `xdg-open` や `gnome-open` を使う場合があるので、 `OPEN_COMMAND` というマクロを追加しました。
